### PR TITLE
[#49] Wire Action 버그 수정

### DIFF
--- a/Assets/_MyAssets/Resources/Player.prefab
+++ b/Assets/_MyAssets/Resources/Player.prefab
@@ -149,7 +149,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 6758291253464975337}
         m_TargetAssemblyTypeName: PlayerMove, Assembly-CSharp
-        m_MethodName: OnWireButtonClick
+        m_MethodName: OnWireAction
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/_MyAssets/Scenes/DemoPlay.unity
+++ b/Assets/_MyAssets/Scenes/DemoPlay.unity
@@ -2919,7 +2919,7 @@ GameObject:
   - component: {fileID: 698009471}
   - component: {fileID: 698009470}
   - component: {fileID: 698009469}
-  m_Layer: 8
+  m_Layer: 9
   m_Name: Floor3
   m_TagString: Ground
   m_Icon: {fileID: 0}
@@ -3543,7 +3543,7 @@ GameObject:
   - component: {fileID: 850195816}
   - component: {fileID: 850195815}
   - component: {fileID: 850195814}
-  m_Layer: 8
+  m_Layer: 9
   m_Name: Floor2
   m_TagString: Ground
   m_Icon: {fileID: 0}
@@ -4890,17 +4890,17 @@ PrefabInstance:
     - target: {fileID: 2565479048514638535, guid: 8e19267338431d941b626d4717bee39f,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.33611068
+      value: 0.33611065
       objectReference: {fileID: 0}
     - target: {fileID: 2565479048514638535, guid: 8e19267338431d941b626d4717bee39f,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.0776481
+      value: 0.077648155
       objectReference: {fileID: 0}
     - target: {fileID: 2565479048514638535, guid: 8e19267338431d941b626d4717bee39f,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.027817361
+      value: -0.027817376
       objectReference: {fileID: 0}
     - target: {fileID: 2601342945410787353, guid: 8e19267338431d941b626d4717bee39f,
         type: 3}
@@ -5055,22 +5055,22 @@ PrefabInstance:
     - target: {fileID: 9164940507914622148, guid: 8e19267338431d941b626d4717bee39f,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9215918
+      value: 0.92159164
       objectReference: {fileID: 0}
     - target: {fileID: 9164940507914622148, guid: 8e19267338431d941b626d4717bee39f,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.38178396
+      value: 0.38178387
       objectReference: {fileID: 0}
     - target: {fileID: 9164940507914622148, guid: 8e19267338431d941b626d4717bee39f,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.06473322
+      value: 0.06473626
       objectReference: {fileID: 0}
     - target: {fileID: 9164940507914622148, guid: 8e19267338431d941b626d4717bee39f,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.026816763
+      value: -0.026818017
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/_MyAssets/Scripts/Player/PlayerMove.cs
+++ b/Assets/_MyAssets/Scripts/Player/PlayerMove.cs
@@ -478,7 +478,7 @@ public class PlayerMove : MonoBehaviour
         _wireAvailableUiRectTransform.position = wireScreenPoint;
     }
 
-    public void OnWireButtonClick(InputAction.CallbackContext context)
+    public void OnWireAction(InputAction.CallbackContext context)
     {
         if (!context.started)
         {
@@ -505,7 +505,10 @@ public class PlayerMove : MonoBehaviour
             return;
         }
 
-        PerformJump();
+        if (IsGrounded)
+        {
+            PerformJump();
+        }
         
         _currentState = (int)EPlayerState.Idle | (int)EPlayerState.Alive;
 


### PR DESCRIPTION
### `Wire Aciton` 중 발생하는 버그에 대해서 수정하였습니다.
- `Wire Action`을 실행하는 과정에서 `IsGrounded`를 확인하여 이미 점프 중이거나 떨어지는 도중 `PerformJump()`를 호출하지 않도록 수정하였습니다.
- `Wire Point`가 이상한 위치에 걸려 원하는 목표까지 도달하지 못하는 문제는 이전 Merge 과정 중 Layer가 한칸 씩 밀려 발생한 오류로 해당하는 오브젝트에 있어야 할 `Ground` Layer가 아닌 `WirePoint` Layer가 걸려있어 정상적으로 변경하여 수정하였습니다.

*추가로 기존 `OnWireButtonClick` 에서 `OnWireAction` 으로 네이밍 변경하였습니다.*

resolved #49
resolved #35 